### PR TITLE
TASK-4017 BUG: Whitespace after commas in chat message is lost

### DIFF
--- a/bukkit/src/main/java/org/wensheng/juicyraspberrypie/RemoteSession.java
+++ b/bukkit/src/main/java/org/wensheng/juicyraspberrypie/RemoteSession.java
@@ -139,14 +139,15 @@ class RemoteSession {
             return;
         }
         String methodName = line.substring(0, line.indexOf("("));
-        String[] args = line.substring(line.indexOf("(") + 1, line.length() - 1).split(",\\s*");
+        String methodArgs = line.substring(line.indexOf("(") + 1, line.length() - 1);
+        String[] args = methodArgs.split(",\\s*");
         if(args.length == 1 && args[0].isEmpty()){
             args = new String[0];
         }
-        handleCommand(methodName, args);
+        handleCommand(methodName, methodArgs, args);
     }
 
-    private void handleCommand(String c, String[] args) {
+    private void handleCommand(final String c, final String allArgs, final String[] args) {
         
         try {
             if (c.equals("world.getBlock")) {
@@ -291,12 +292,7 @@ class RemoteSession {
             } else if (c.equals("world.getHeight")) {
                 send(originWorld.getHighestBlockYAt(parseLocation(args[0], "0", args[1])));
             } else if (c.equals("chat.post")) {
-                StringBuilder sb = new StringBuilder();
-                for (String arg : args) {
-                    sb.append(arg).append(",");
-                }
-                sb.setLength(sb.length() - 1);
-                plugin.getServer().broadcastMessage(sb.toString());
+                plugin.getServer().broadcastMessage(allArgs);
             } else if (c.equals("events.clear")) {
                 interactEventQueue.clear();
                 chatPostedQueue.clear();

--- a/bukkit/src/main/java/org/wensheng/juicyraspberrypie/RemoteSession.java
+++ b/bukkit/src/main/java/org/wensheng/juicyraspberrypie/RemoteSession.java
@@ -133,11 +133,11 @@ class RemoteSession {
     }
 
     private void handleLine(String line) {
-        if(!line.contains("(") || !line.contains(")")){
+        line = line.trim();
+        if(!line.contains("(") || !line.endsWith(")")){
             send("Wrong format");
             return;
         }
-        line = line.trim();
         String methodName = line.substring(0, line.indexOf("("));
         String[] args = line.substring(line.indexOf("(") + 1, line.length() - 1).split(",\\s*");
         if(args.length == 1 && args[0].isEmpty()){


### PR DESCRIPTION
The protocol has no notion of a quoted string and instead sends the `chat.post` arguments as-is. The server splits on commas into individual arguments, and `chat.post` undoes that by re-joining with commas. With this approach, any whitespace after a comma gets lost.  
Also pass `allArgs` to `handleCommand()` and directly use that for `Server#broadcastMessage()`.

Server: `rebuild-task-4017-bug-chat-commas-world-p.dev-join.reload.works`