### PR TITLE
TASK-4017 Overwrite non-config resources on each plugin startup

### DIFF
--- a/bukkit/src/main/java/org/wensheng/juicyraspberrypie/JuicyRaspberryPie.java
+++ b/bukkit/src/main/java/org/wensheng/juicyraspberrypie/JuicyRaspberryPie.java
@@ -39,39 +39,30 @@ public class JuicyRaspberryPie extends JavaPlugin implements Listener{
         }
 
         File svrFolder = new File(getDataFolder(), "cmdsvr");
-        if(!svrFolder.exists()) {
-            boolean ok = svrFolder.mkdir();
-            if (ok) {
-                this.saveResource("cmdsvr/pycmdsvr.py", false);
-            } else {
-                logger.warning("Could not create cmdsvr directory in plugin.");
-            }
+        if (svrFolder.exists() || svrFolder.mkdir()) {
+                this.saveResource("cmdsvr/pycmdsvr.py", true);
+        } else {
+            logger.warning("Could not create cmdsvr directory in plugin.");
         }
 
         File mcpiFolder = new File(getDataFolder(), "mcpi");
-        if(!mcpiFolder.exists()) {
-            boolean ok = mcpiFolder.mkdir();
-            if (ok) {
-                this.saveResource("mcpi/__init__.py", false);
-                this.saveResource("mcpi/connection.py", false);
-                this.saveResource("mcpi/event.py", false);
-                this.saveResource("mcpi/minecraft.py", false);
-                this.saveResource("mcpi/util.py", false);
-                this.saveResource("mcpi/vec3.py", false);
-            } else {
-                logger.warning("Could not create mcpi directory in plugin.");
-            }
+        if (mcpiFolder.exists() || mcpiFolder.mkdir()) {
+            this.saveResource("mcpi/__init__.py", true);
+            this.saveResource("mcpi/connection.py", true);
+            this.saveResource("mcpi/event.py", true);
+            this.saveResource("mcpi/minecraft.py", true);
+            this.saveResource("mcpi/util.py", true);
+            this.saveResource("mcpi/vec3.py", true);
+        } else {
+            logger.warning("Could not create mcpi directory in plugin.");
         }
 
         File ppluginsFolder = new File(getDataFolder(), "pplugins");
-        if(!ppluginsFolder.exists()){
-            boolean ok = ppluginsFolder.mkdir();
-            if(ok){
-                this.saveResource("pplugins/README.txt", false);
-                this.saveResource("pplugins/examples.py", false);
-            } else {
-                logger.warning("Could not create pplugins directory in plugin.");
-            }
+        if (ppluginsFolder.exists() || ppluginsFolder.mkdir()){
+            this.saveResource("pplugins/README.txt", true);
+            this.saveResource("pplugins/examples.py", true);
+        } else {
+            logger.warning("Could not create pplugins directory in plugin.");
         }
     }
     


### PR DESCRIPTION
We just wondered (on Maximilian's game development server) why it still had an outdated _mcpi_ library; the reason is that once the files have been written to the file system (in fact, even once the directory those are in exists), all those resources aren't written.
This makes sense for the plugin configuration, but cmdsvr, mcpi, and pplugins are all delivered by JuicyRaspberryPie and should not be modified by the user.
Don't skip saveResource() when the directory already exists and set the overwrite flag, too. This also reduces the complexity of the code a bit.

Server: `rebuild-task-4017-overwrite-mcpi-world-pr.dev-join.reload.works`