### PR TITLE
TASK-4121 Add Player.performCommand(command) to execute arbitrary Minecraft commands

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>2.0.2</revision>
+		<revision>2.1.0</revision>
 		<changelist>-SNAPSHOT</changelist>
 	</properties>
 

--- a/src/main/java/org/wensheng/juicyraspberrypie/RemoteSession.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/RemoteSession.java
@@ -29,7 +29,6 @@ import org.wensheng.juicyraspberrypie.command.handlers.entity.WalkTo;
 import org.wensheng.juicyraspberrypie.command.handlers.events.Clear;
 import org.wensheng.juicyraspberrypie.command.handlers.events.EventQueue;
 import org.wensheng.juicyraspberrypie.command.handlers.events.chat.Posts;
-import org.wensheng.juicyraspberrypie.command.handlers.player.PerformCommand;
 import org.wensheng.juicyraspberrypie.command.handlers.world.GetBlock;
 import org.wensheng.juicyraspberrypie.command.handlers.world.GetBlockWithData;
 import org.wensheng.juicyraspberrypie.command.handlers.world.GetBlocks;
@@ -336,7 +335,8 @@ class RemoteSession {
 		registry.register("entity.disableControl", new DisableControl(plugin, entityProvider));
 		registry.register("entity.walkTo", new WalkTo(entityProvider));
 		registry.register("entity.remove", new Remove(entityProvider));
-		registry.register("player.performCommand", new PerformCommand(attachment));
+		registry.register("player.performCommand", new org.wensheng.juicyraspberrypie.command.handlers.player.PerformCommand(attachment));
+		registry.register("console.performCommand", new org.wensheng.juicyraspberrypie.command.handlers.console.PerformCommand());
 
 		registry.getHandlers().stream()
 				.filter(handler -> handler instanceof EventQueue<?>)

--- a/src/main/java/org/wensheng/juicyraspberrypie/RemoteSession.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/RemoteSession.java
@@ -336,7 +336,8 @@ class RemoteSession {
 		registry.register("entity.walkTo", new WalkTo(entityProvider));
 		registry.register("entity.remove", new Remove(entityProvider));
 		registry.register("player.performCommand", new org.wensheng.juicyraspberrypie.command.handlers.player.PerformCommand(attachment));
-		registry.register("console.performCommand", new org.wensheng.juicyraspberrypie.command.handlers.console.PerformCommand(plugin.getConfig().getStringList("console-command-whitelist")));
+		registry.register("console.performCommand", new org.wensheng.juicyraspberrypie.command.handlers.console.PerformCommand(
+				plugin.getLogger(), plugin.getConfig().getStringList("console-command-whitelist")));
 
 		registry.getHandlers().stream()
 				.filter(handler -> handler instanceof EventQueue<?>)

--- a/src/main/java/org/wensheng/juicyraspberrypie/RemoteSession.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/RemoteSession.java
@@ -29,6 +29,7 @@ import org.wensheng.juicyraspberrypie.command.handlers.entity.WalkTo;
 import org.wensheng.juicyraspberrypie.command.handlers.events.Clear;
 import org.wensheng.juicyraspberrypie.command.handlers.events.EventQueue;
 import org.wensheng.juicyraspberrypie.command.handlers.events.chat.Posts;
+import org.wensheng.juicyraspberrypie.command.handlers.player.PerformCommand;
 import org.wensheng.juicyraspberrypie.command.handlers.world.GetBlock;
 import org.wensheng.juicyraspberrypie.command.handlers.world.GetBlockWithData;
 import org.wensheng.juicyraspberrypie.command.handlers.world.GetBlocks;
@@ -335,6 +336,7 @@ class RemoteSession {
 		registry.register("entity.disableControl", new DisableControl(plugin, entityProvider));
 		registry.register("entity.walkTo", new WalkTo(entityProvider));
 		registry.register("entity.remove", new Remove(entityProvider));
+		registry.register("player.performCommand", new PerformCommand(attachment));
 
 		registry.getHandlers().stream()
 				.filter(handler -> handler instanceof EventQueue<?>)

--- a/src/main/java/org/wensheng/juicyraspberrypie/RemoteSession.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/RemoteSession.java
@@ -336,7 +336,7 @@ class RemoteSession {
 		registry.register("entity.walkTo", new WalkTo(entityProvider));
 		registry.register("entity.remove", new Remove(entityProvider));
 		registry.register("player.performCommand", new org.wensheng.juicyraspberrypie.command.handlers.player.PerformCommand(attachment));
-		registry.register("console.performCommand", new org.wensheng.juicyraspberrypie.command.handlers.console.PerformCommand());
+		registry.register("console.performCommand", new org.wensheng.juicyraspberrypie.command.handlers.console.PerformCommand(plugin.getConfig().getStringList("console-command-whitelist")));
 
 		registry.getHandlers().stream()
 				.filter(handler -> handler instanceof EventQueue<?>)

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/console/PerformCommand.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/console/PerformCommand.java
@@ -1,0 +1,21 @@
+package org.wensheng.juicyraspberrypie.command.handlers.console;
+
+import org.bukkit.Bukkit;
+import org.wensheng.juicyraspberrypie.command.Handler;
+import org.wensheng.juicyraspberrypie.command.Instruction;
+
+/**
+ * Execute the given command on the console.
+ */
+public class PerformCommand implements Handler {
+	/**
+	 * Create a new PerformCommand event handler.
+	 */
+	public PerformCommand() {
+	}
+
+	@Override
+	public String handle(final Instruction instruction) {
+		return String.valueOf(Bukkit.dispatchCommand(Bukkit.getConsoleSender(), instruction.next()));
+	}
+}

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/console/PerformCommand.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/console/PerformCommand.java
@@ -1,21 +1,41 @@
 package org.wensheng.juicyraspberrypie.command.handlers.console;
 
 import org.bukkit.Bukkit;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
 
 /**
  * Execute the given command on the console.
  */
 public class PerformCommand implements Handler {
 	/**
-	 * Create a new PerformCommand event handler.
+	 * The configured whitelist patterns for commands.
+	 * Anchored Java regular expressions; at least one must match for a command to be allowed.
 	 */
-	public PerformCommand() {
+	@NotNull
+	private final List<Pattern> whitelistPatterns;
+
+	/**
+	 * Create a new PerformCommand event handler.
+	 *
+	 * @param whitelistPattern The whitelist patterns to associate with this handler.
+	 */
+	public PerformCommand(@NotNull final List<String> whitelistPattern) {
+		this.whitelistPatterns = Objects.requireNonNull(whitelistPattern).stream().map(Pattern::compile).toList();
 	}
 
 	@Override
-	public String handle(final Instruction instruction) {
-		return String.valueOf(Bukkit.dispatchCommand(Bukkit.getConsoleSender(), instruction.next()));
+	public String handle(@NotNull final Instruction instruction) {
+		final String command = instruction.next();
+		if (whitelistPatterns.stream().noneMatch(pattern -> pattern.matcher(command).matches())) {
+			return "Fail: Command rejected: " + command;
+		}
+
+		return String.valueOf(Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command));
 	}
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/console/PerformCommand.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/console/PerformCommand.java
@@ -7,6 +7,7 @@ import org.wensheng.juicyraspberrypie.command.Instruction;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 /**
@@ -20,12 +21,17 @@ public class PerformCommand implements Handler {
 	@NotNull
 	private final List<Pattern> whitelistPatterns;
 
+	/** The logger. */
+	private final Logger logger;
+
 	/**
 	 * Create a new PerformCommand event handler.
 	 *
+	 * @param logger The logger.
 	 * @param whitelistPattern The whitelist patterns to associate with this handler.
 	 */
-	public PerformCommand(@NotNull final List<String> whitelistPattern) {
+	public PerformCommand(@NotNull final Logger logger, @NotNull final List<String> whitelistPattern) {
+		this.logger = Objects.requireNonNull(logger);
 		this.whitelistPatterns = Objects.requireNonNull(whitelistPattern).stream().map(Pattern::compile).toList();
 	}
 
@@ -33,6 +39,7 @@ public class PerformCommand implements Handler {
 	public String handle(@NotNull final Instruction instruction) {
 		final String command = instruction.next();
 		if (whitelistPatterns.stream().noneMatch(pattern -> pattern.matcher(command).matches())) {
+			logger.warning("Rejected command because it is not matched by the whitelist: " + command);
 			return "Fail: Command rejected: " + command;
 		}
 

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/player/PerformCommand.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/player/PerformCommand.java
@@ -1,0 +1,29 @@
+package org.wensheng.juicyraspberrypie.command.handlers.player;
+
+import org.wensheng.juicyraspberrypie.command.Handler;
+import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
+
+/**
+ * Make the player associated with the current session perform the given command.
+ */
+public class PerformCommand implements Handler {
+	/**
+	 * The session attachment associated with this handler.
+	 */
+	private final SessionAttachment attachment;
+
+	/**
+	 * Create a new PerformCommand event handler.
+	 *
+	 * @param attachment The session attachment to associate with this handler.
+	 */
+	public PerformCommand(final SessionAttachment attachment) {
+		this.attachment = attachment;
+	}
+
+	@Override
+	public String handle(final Instruction instruction) {
+		return String.valueOf(attachment.getPlayer().performCommand(instruction.next()));
+	}
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,3 +5,4 @@ cmdsvr_port: 4731
 pyexe: "/usr/bin/python3"
 # windows pyexe example
 # pyexe: "C:\\Users\\wensheng\\Anaconda3\\python.exe"
+console-command-whitelist:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,4 +5,4 @@ cmdsvr_port: 4731
 pyexe: "/usr/bin/python3"
 # windows pyexe example
 # pyexe: "C:\\Users\\wensheng\\Anaconda3\\python.exe"
-console-command-whitelist:
+console-command-whitelist: []


### PR DESCRIPTION
python/mcpi [faf65db..662ba98](https://github.com/ResilientGroup/mcpi/compare/faf65db...662ba98):
* TASK-4121 Add Minecraft.performCommand(command) to execute arbitrary Minecraft commands on the console
* TASK-4121 Add Player.performCommand(command) to execute arbitrary Minecraft commands
* Refactoring: Extract Connection.sendReceiveBool()

<!-- BEGIN Global settings -->

---
<!-- Git and GitHub -->
- [X] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [X] Include a human-readable description of what the pull request is trying to accomplish
- [X] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [X] Steps for the reviewer(s) on how they can manually QA the changes:
  - [X] Execute `mc.player.performCommand("help")`
  - [X] Add commands to the whitelist [^1] and execute an allowed (`mc.performCommand("help")`) and disallowed console command (`mc.performCommand("stop")`)
- [ ] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [ ] No (significant) changes to production code
---
<!-- Documentation -->
- [X] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted:
<!-- END Global settings -->
---
<!-- Support matrix -->
- [ ] The change is unrelated to Minecraft
- [X] Works in Java edition
- [X] Works in Bedrock edition

[^1]: plugins/JuicyRaspberryPie/config.yml with contents &uarr;

```yaml
api_port: 4711
console-command-whitelist:
  - help.*
```
