### PR TITLE
Bump: Minor: Maven parent, Maven Wrapper, lock paper-api snapshot dependency

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-wrapperVersion=3.3.1
+wrapperVersion=3.3.2
+distributionType=only-script
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+# HELP
+# This will output the help for each task
+# thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+.PHONY: help \
+	update-dependencies update-snapshot-dependencies bump-version
+
+help: ## This help.
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+.DEFAULT_GOAL := help
+
+MAVEN_COMMAND ?= ./mvnw
+
+# Updates of third-party dependencies
+update-dependencies: update-maven-parent update-dependencies update-snapshot-dependencies ## Update all Maven dependencies
+
+update-maven-parent: ## Update Maven parent POM version
+	$(MAVEN_COMMAND) --non-recursive clean -DgenerateBackupPoms=false versions:update-parent
+
+update-dependencies: ## Update Maven dependencies and plugins which have versions defined in properties
+	$(MAVEN_COMMAND) --non-recursive clean -DgenerateBackupPoms=false versions:update-properties
+
+update-snapshot-dependencies: ## Update locked snapshot versions with the latest available one in the POM
+	$(MAVEN_COMMAND) --non-recursive -DgenerateBackupPoms=false versions:unlock-snapshots versions:lock-snapshots
+
+bump-version: ## Bump the version of the project
+	@if [ -z "$(NEW_VERSION)" ]; then echo 'ERROR: NEW_VERSION is not set.'; exit 2; fi
+	$(MAVEN_COMMAND) versions:set-property -DgenerateBackupPoms=false -Dproperty=revision -DnewVersion=$(NEW_VERSION)

--- a/mvnw
+++ b/mvnw
@@ -19,7 +19,7 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Apache Maven Wrapper startup batch script, version 3.3.1
+# Apache Maven Wrapper startup batch script, version 3.3.2
 #
 # Optional ENV vars
 # -----------------
@@ -97,11 +97,19 @@ die() {
   exit 1
 }
 
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
 # parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
 while IFS="=" read -r key value; do
   case "${key-}" in
-  distributionUrl) distributionUrl="${value-}" ;;
-  distributionSha256Sum) distributionSha256Sum="${value-}" ;;
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
   esac
 done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
 [ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
@@ -131,7 +139,8 @@ esac
 distributionUrlName="${distributionUrl##*/}"
 distributionUrlNameMain="${distributionUrlName%.*}"
 distributionUrlNameMain="${distributionUrlNameMain%-bin}"
-MAVEN_HOME="$HOME/.m2/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
 
 exec_maven() {
   unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -19,7 +19,7 @@
 @REM ----------------------------------------------------------------------------
 
 @REM ----------------------------------------------------------------------------
-@REM Apache Maven Wrapper startup batch script, version 3.3.1
+@REM Apache Maven Wrapper startup batch script, version 3.3.2
 @REM
 @REM Optional ENV vars
 @REM   MVNW_REPOURL - repo url base for downloading maven distribution
@@ -79,6 +79,9 @@ if ($env:MVNW_REPOURL) {
 $distributionUrlName = $distributionUrl -replace '^.*/',''
 $distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
 $MAVEN_HOME_PARENT = "$HOME/.m2/wrapper/dists/$distributionUrlNameMain"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_HOME_PARENT = "$env:MAVEN_USER_HOME/wrapper/dists/$distributionUrlNameMain"
+}
 $MAVEN_HOME_NAME = ([System.Security.Cryptography.MD5]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
 $MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>works.reload</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.2</version>
 		<relativePath/>
 	</parent>
 
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>io.papermc.paper</groupId>
 			<artifactId>paper-api</artifactId>
-			<version>1.20.2-R0.1-SNAPSHOT</version>
+			<version>1.20.2-R0.1-20231203.034718-122</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
As a preparation: Add Makefile to update the various Maven dependencies


<!-- BEGIN Global settings -->
---
<!-- Git and GitHub -->
- [ ] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [X] Include a human-readable description of what the pull request is trying to accomplish
- [X] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
- [X] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [X] No (significant) changes to production code
---
<!-- Documentation -->
- [ ] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted:
<!-- END Global settings -->
---
<!-- Support matrix -->
- [X] The change is unrelated to Minecraft
- [ ] Works in Java edition
- [ ] Works in Bedrock edition