### PR TITLE
Build: Refactoring: Reuse MavenSetup generic Java build workflow and bump version to 2.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,24 +10,5 @@ on:
 
 jobs:
   build:
-    name: Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Setup Java and Maven
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 21
-          cache: 'maven'
-      - name: Build with Maven verify
-        run: ./mvnw -B verify
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: Artifacts
-          path: |
-            target/*.jar
+    uses: ResilientGroup/MavenSetup/.github/workflows/build.yml@1.3.0
+    secrets: inherit

--- a/doc/using-api-spigot.md
+++ b/doc/using-api-spigot.md
@@ -17,7 +17,7 @@ Installation video: https://youtu.be/6-bqPcMoZ8M
 reference: https://www.spigotmc.org/wiki/spigot-installation/
 
 ## JuicyRaspberryPie Plugin Installation
-1. Download juicyraspberrypie-1.18.1.jar from https://github.com/wensheng/JuicyRaspberryPie/releases
+1. Download `juicyraspberrypie-VERSION.jar` from https://nexus.reloadkube.managedservices.resilient-teched.com/#browse/browse:reload:org%2Fwensheng%2Fjuicyraspberrypie
 2. Move the file to `plugins` folder, the folder is at the same place where Spigot.jar is.
 3. Start or reload Spigot. (To reload, just type `reload` in Spigot command window)
 4. When juicyraspberrypie.jar is loaded for the 1st time, a folder `JuicyRaspberryPie` will be created under plugins folder.

--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,15 @@
 
 	<groupId>org.wensheng</groupId>
 	<artifactId>juicyraspberrypie</artifactId>
-	<version>1.18.1</version>
+	<version>${revision}${changelist}</version>
 	<name>JuicyRaspberryPie</name>
 	<description>Plugin to execute python code</description>
+
+	<properties>
+		<!-- project version -->
+		<revision>2.0.0</revision>
+		<changelist>-SNAPSHOT</changelist>
+	</properties>
 
 	<repositories>
 		<repository>


### PR DESCRIPTION
In order to tag and publish the built artifacts \(JARs\) to our Maven repository. The MavenSetup workflow does that already, and can be reused as-is.  
This replaces the _upload as GitHub artifacts_; unlike the original repo, we haven't done any GitHub releases.  
In fact, we didn't even touch the original version number so far; let's deviate from the original "following the compatible Minecraft release" versioning \(which doesn't make sense for us and likely isn't a good idea in general\) and instead restart with a 2.0.0 SemVer.  
Our Maven repo is \(for us\) a more consistent and comfortable way of publishing \(as we can use Maven version ranges and reference snapshot releases\) than using GitHub releases.  

Use 2.0.0 for the changes in our fork; we didn't have a proper release process in place so far, and lazily stuck to the original forked version. As we've made quite some \(also incompatible\) changes, a new major version \(and following SemVer now\) is required.  

<!-- BEGIN Global settings -->

---
<!-- Git and GitHub -->
- [ ] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [X] Include a human-readable description of what the pull request is trying to accomplish
- [X] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
- [X] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [X] No (significant) changes to production code
---
<!-- Documentation -->
- [ ] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted:
<!-- END Global settings -->
---
<!-- Support matrix -->
- [X] The change is unrelated to Minecraft
- [ ] Works in Java edition
- [ ] Works in Bedrock edition