### PR TITLE
TASK-4121 FIX: mc.postToChat("Hello,,world") results in "Hello,null,world", command ends after the first comma

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>2.1.0</revision>
+		<revision>2.1.1</revision>
 		<changelist>-SNAPSHOT</changelist>
 	</properties>
 

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/Instruction.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/Instruction.java
@@ -3,6 +3,7 @@ package org.wensheng.juicyraspberrypie.command;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
+import org.codehaus.plexus.util.StringUtils;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -108,5 +109,14 @@ public class Instruction implements Iterator<String> {
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Get all (remaining) arguments as a single String.
+	 *
+	 * @return all arguments joined together
+	 */
+	public String allArguments() {
+		return StringUtils.join(this, ",");
 	}
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/Instruction.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/Instruction.java
@@ -3,10 +3,13 @@ package org.wensheng.juicyraspberrypie.command;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
-import org.codehaus.plexus.util.StringUtils;
 
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * An instruction for a command.
@@ -117,6 +120,8 @@ public class Instruction implements Iterator<String> {
 	 * @return all arguments joined together
 	 */
 	public String allArguments() {
-		return StringUtils.join(this, ",");
+		return StreamSupport.stream(Spliterators.spliteratorUnknownSize(this, Spliterator.ORDERED), false)
+				.map(arg -> arg == null ? "" : arg)
+				.collect(Collectors.joining(","));
 	}
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/chat/Post.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/chat/Post.java
@@ -1,7 +1,6 @@
 package org.wensheng.juicyraspberrypie.command.handlers.chat;
 
 import org.bukkit.Server;
-import org.codehaus.plexus.util.StringUtils;
 import org.wensheng.juicyraspberrypie.command.HandlerVoid;
 import org.wensheng.juicyraspberrypie.command.Instruction;
 
@@ -26,7 +25,7 @@ public class Post implements HandlerVoid {
 
 	@Override
 	public void handleVoid(final Instruction instruction) {
-		final String message = StringUtils.join(instruction, ",");
+		final String message = instruction.allArguments();
 		server.broadcastMessage(message);
 	}
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/console/PerformCommand.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/console/PerformCommand.java
@@ -37,7 +37,7 @@ public class PerformCommand implements Handler {
 
 	@Override
 	public String handle(@NotNull final Instruction instruction) {
-		final String command = instruction.next();
+		final String command = instruction.allArguments();
 		if (whitelistPatterns.stream().noneMatch(pattern -> pattern.matcher(command).matches())) {
 			logger.warning("Rejected command because it is not matched by the whitelist: " + command);
 			return "Fail: Command rejected: " + command;

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/player/PerformCommand.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/player/PerformCommand.java
@@ -24,6 +24,6 @@ public class PerformCommand implements Handler {
 
 	@Override
 	public String handle(final Instruction instruction) {
-		return String.valueOf(attachment.getPlayer().performCommand(instruction.next()));
+		return String.valueOf(attachment.getPlayer().performCommand(instruction.allArguments()));
 	}
 }

--- a/src/test/java/org/wensheng/juicyraspberrypie/command/InstructionTests.java
+++ b/src/test/java/org/wensheng/juicyraspberrypie/command/InstructionTests.java
@@ -1,0 +1,51 @@
+package org.wensheng.juicyraspberrypie.command;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+class InstructionTests {
+	@Nested
+	class allArguments {
+		@SuppressWarnings("PMD.UnusedPrivateMethod")
+		private static @NotNull Stream<Arguments> consumption() {
+			return Stream.of(
+					Arguments.of("", (Object) new String[0]),
+					Arguments.of("one", (Object) new String[]{"one"}),
+					Arguments.of("one,two,and three", (Object) new String[]{"one", "two", "and three"}),
+					Arguments.of("", (Object) new String[]{null}),
+					Arguments.of(",", (Object) new String[]{null, null}),
+					Arguments.of("one,,three", (Object) new String[]{"one", null, "three"}),
+					Arguments.of(",two,", (Object) new String[]{null, "two", null})
+			);
+		}
+
+		@ParameterizedTest
+		@MethodSource
+		void consumption(@NotNull final String expected, @NotNull final String... args) {
+			assertThat(new Instruction(args, null).allArguments(), is(equalTo(expected)));
+		}
+
+		@Test
+		void consumes_remaining_arguments() {
+			final Instruction instruction = new Instruction(new String[]{"one", "two", "three"}, null);
+			instruction.next();
+			assertThat(instruction.allArguments(), is("two,three"));
+		}
+
+		@Test
+		void fully_consumes_arguments() {
+			final Instruction instruction = new Instruction(new String[]{"one", "two", "three"}, null);
+			instruction.allArguments();
+			assertThat(instruction.hasNext(), is(false));
+		}
+	}
+}


### PR DESCRIPTION
Consecutive commas are converted into `null`s; this has to be undone when joining, turning each `null` into the empty String.  

The new Minecraft commands need to consume all arguments; now there's `Instruction#allArguments()` for that.

<!-- BEGIN Global settings -->

---
<!-- Git and GitHub -->
- [X] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [X] Include a human-readable description of what the pull request is trying to accomplish
- [X] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [X] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [X] Steps for the reviewer(s) on how they can manually QA the changes:
  - [X] `mc.postToChat("Hello,,world")` results in `Hello,,world`
  - [X] `mc.performCommand("msg @p Hello,,world")` results in `Hello,,world`
- [ ] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [ ] No (significant) changes to production code
---
<!-- Documentation -->
- [X] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted:
<!-- END Global settings -->
---
<!-- Support matrix -->
- [X] The change is unrelated to Minecraft
- [ ] Works in Java edition
- [ ] Works in Bedrock edition