### PR TITLE
TASK-4121 Build JavaDocs and site and add mcpi documentation to JuicyRaspberryPie's site in Google Cloud

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,16 @@ on:
 
 jobs:
   build:
-    uses: ResilientGroup/MavenSetup/.github/workflows/build.yml@1.3.2
+    uses: ResilientGroup/MavenSetup/.github/workflows/build.yml@1.4.0
+    with:
+      javadoc-project-name: JuicyRaspberryPie
     secrets: inherit
+
   build-python:
     runs-on: ubuntu-latest
+    needs: build
+    env:
+      DOC_STAGING_DIR: target/staging
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -33,6 +39,26 @@ jobs:
       - name: Build documentation
         run: |
           source .venv/bin/activate
-          pdoc --html --output-dir target mcpi
+          pdoc --html --output-dir ${{ env.DOC_STAGING_DIR }} mcpi
         working-directory: ./python/mcpi
         shell: bash
+
+      - name: Authenticate with Google Cloud
+        if: github.ref == 'refs/heads/main'
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.CLOUDBUILD_COMMON_GCP_KEY }}
+      - name: Upload latest Python docs copy to Google Cloud Storage
+        if: github.ref == 'refs/heads/main'
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: python/mcpi/${{ env.DOC_STAGING_DIR }}/mcpi
+          destination: resilient-reload-javadoc/JuicyRaspberryPie/latest
+          process_gcloudignore: false
+      - name: Upload versioned Python docs to Google Cloud Storage
+        if: needs.build.outputs.release-version != ''
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: python/mcpi/${{ env.DOC_STAGING_DIR }}/mcpi
+          destination: resilient-reload-javadoc/JuicyRaspberryPie/${{ needs.build.outputs.release-version }}
+          process_gcloudignore: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,3 +12,27 @@ jobs:
   build:
     uses: ResilientGroup/MavenSetup/.github/workflows/build.yml@1.3.2
     secrets: inherit
+  build-python:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          cache: pip
+      - name: Setup Python venv
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install --requirement ./requirements.txt
+        working-directory: ./python/mcpi
+        shell: bash
+      - name: Build documentation
+        run: |
+          source .venv/bin/activate
+          pdoc --html --output-dir target mcpi
+        working-directory: ./python/mcpi
+        shell: bash

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,13 @@
 		</repository>
 	</repositories>
 
+	<distributionManagement>
+		<site>
+			<id>${project.artifactId}-site</id>
+			<url>file:///tmp/dummy-site</url> <!-- Needs to be defined here to avoid that "juicyraspberrypie" is appended to the staging directory. -->
+		</site>
+	</distributionManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>io.papermc.paper</groupId>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/DECORATION/1.6.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/DECORATION/1.6.0 http://maven.apache.org/xsd/decoration-1.6.0.xsd">
+	<skin>
+		<groupId>org.apache.maven.skins</groupId>
+		<artifactId>maven-fluido-skin</artifactId>
+		<version>2.0.0-M9</version>
+	</skin>
+
+	<body>
+		<menu ref="modules"/>
+		<menu ref="reports"/>
+		<menu name="Sub-Projects">
+			<item name="mcpi" href="mcpi/index.html"/>
+		</menu>
+	</body>
+</project>


### PR DESCRIPTION
python/mcpi [11be260..8da7237](https://github.com/ResilientGroup/mcpi/compare/11be260...8da7237):
* TASK-4121 Add pdoc3

Build JavaDoc via the new MavenSetup workflow, and in addition JavaDoc-like documentation of the mcpi API, then add that to the site's link list.

<!-- BEGIN Global settings -->

---
<!-- Git and GitHub -->
- [X] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [X] Include a human-readable description of what the pull request is trying to accomplish
- [X] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [X] Steps for the reviewer(s) on how they can manually QA the changes:
  - [X] A trial upload succeeded
- [X] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [X] No (significant) changes to production code
---
<!-- Documentation -->
- [ ] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted:
<!-- END Global settings -->
---
<!-- Support matrix -->
- [X] The change is unrelated to Minecraft
- [ ] Works in Java edition
- [ ] Works in Bedrock edition