### PR TITLE
TASK-4337 Refactoring towards a single Registry instance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>2.1.6</revision>
+		<revision>2.1.7</revision>
 		<changelist>-SNAPSHOT</changelist>
 	</properties>
 

--- a/src/main/java/org/wensheng/juicyraspberrypie/RemoteSession.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/RemoteSession.java
@@ -89,6 +89,8 @@ class RemoteSession {
 
 	private final LocationParser locationParser;
 
+	private final SessionAttachment attachment;
+
 	@SuppressFBWarnings("CT_CONSTRUCTOR_THROW")
 	public RemoteSession(final JuicyRaspberryPie plugin, final Socket socket) throws IOException {
 		this.socket = socket;
@@ -97,10 +99,10 @@ class RemoteSession {
 		init();
 		registry = new Registry();
 
-		final SessionAttachment attachment = new SessionAttachment(plugin.getServer());
+		attachment = new SessionAttachment(plugin.getServer());
 		attachment.setPlayerAndOrigin();
 		locationParser = new LocationParser(attachment);
-		setupRegistry(attachment);
+		setupRegistry();
 	}
 
 	private void init() throws IOException {
@@ -168,7 +170,7 @@ class RemoteSession {
 	private void handleCommand(final String command, final String... args) {
 		final Handler handler = registry.getHandler(command);
 		if (handler != null) {
-			send(handler.get(new Instruction(args, locationParser)));
+			send(handler.get(attachment, new Instruction(args, locationParser)));
 			return;
 		}
 		plugin.getLogger().warning(command + " is not supported.");
@@ -286,12 +288,12 @@ class RemoteSession {
 		}
 	}
 
-	private void setupRegistry(final SessionAttachment attachment) {
-		final EntityByPlayerNameProvider playerEntityProvider = new EntityByPlayerNameProvider(attachment);
+	private void setupRegistry() {
+		final EntityByPlayerNameProvider playerEntityProvider = new EntityByPlayerNameProvider();
 		final EntityByUUIDProvider entityProvider = new EntityByUUIDProvider(plugin.getServer());
 
-		registry.register("getPlayer", new GetPlayer(attachment));
-		registry.register("setPlayer", new SetPlayer(attachment));
+		registry.register("getPlayer", new GetPlayer());
+		registry.register("setPlayer", new SetPlayer());
 		registry.register("world.getBlock", new GetBlock());
 		registry.register("world.getBlocks", new GetBlocks());
 		registry.register("world.getBlockWithData", new GetBlockWithData());
@@ -335,7 +337,7 @@ class RemoteSession {
 		registry.register("entity.disableControl", new DisableControl(plugin, entityProvider));
 		registry.register("entity.walkTo", new WalkTo(entityProvider));
 		registry.register("entity.remove", new Remove(entityProvider));
-		registry.register("player.performCommand", new org.wensheng.juicyraspberrypie.command.handlers.player.PerformCommand(attachment));
+		registry.register("player.performCommand", new org.wensheng.juicyraspberrypie.command.handlers.player.PerformCommand());
 		registry.register("console.performCommand", new org.wensheng.juicyraspberrypie.command.handlers.console.PerformCommand(
 				plugin.getLogger(), plugin.getConfig().getStringList("console-command-whitelist")));
 

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/Handler.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/Handler.java
@@ -36,26 +36,6 @@ public interface Handler {
 	String handle(Instruction instruction);
 
 	/**
-	 * Get the location as a string from the given location.
-	 *
-	 * @param loc the location
-	 * @return the location as a string
-	 */
-	default String getLocation(final Location loc) {
-		return loc.getX() + "," + loc.getY() + "," + loc.getZ();
-	}
-
-	/**
-	 * Get the block location as a string from the given location.
-	 *
-	 * @param loc the location
-	 * @return the block location as a string
-	 */
-	default String getBlockLocation(final Location loc) {
-		return loc.getBlockX() + "," + loc.getBlockY() + "," + loc.getBlockZ();
-	}
-
-	/**
 	 * Get the locations between the given locations.
 	 *
 	 * @param loc1 the first location

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/Handler.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/Handler.java
@@ -1,5 +1,7 @@
 package org.wensheng.juicyraspberrypie.command;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * A handler for a command.
  */
@@ -12,9 +14,9 @@ public interface Handler {
 	 * @return the result
 	 */
 	@SuppressWarnings({"PMD.AvoidPrintStackTrace", "PMD.AvoidCatchingGenericException"})
-	default String get(final Instruction instruction) {
+	default String get(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		try {
-			return handle(instruction);
+			return handle(sessionAttachment, instruction);
 		} catch (final Exception e) {
 			e.printStackTrace();
 			return "Fail: " + e.getMessage();
@@ -24,8 +26,9 @@ public interface Handler {
 	/**
 	 * Handle the instruction for a command and return the result.
 	 *
-	 * @param instruction the instruction
+	 * @param sessionAttachment the session attachment
+	 * @param instruction       the instruction
 	 * @return the result
 	 */
-	String handle(Instruction instruction);
+	String handle(@NotNull SessionAttachment sessionAttachment, @NotNull Instruction instruction);
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/Handler.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/Handler.java
@@ -1,11 +1,5 @@
 package org.wensheng.juicyraspberrypie.command;
 
-import org.bukkit.Location;
-import org.bukkit.World;
-
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * A handler for a command.
  */
@@ -34,31 +28,4 @@ public interface Handler {
 	 * @return the result
 	 */
 	String handle(Instruction instruction);
-
-	/**
-	 * Get the locations between the given locations.
-	 *
-	 * @param loc1 the first location
-	 * @param loc2 the second location
-	 * @return the locations
-	 */
-	default List<Location> getLocationsBetween(final Location loc1, final Location loc2) {
-		final List<Location> locations = new ArrayList<>();
-		final World world = loc1.getWorld();
-		final int minX = Math.min(loc1.getBlockX(), loc2.getBlockX());
-		final int maxX = Math.max(loc1.getBlockX(), loc2.getBlockX());
-		final int minY = Math.min(loc1.getBlockY(), loc2.getBlockY());
-		final int maxY = Math.max(loc1.getBlockY(), loc2.getBlockY());
-		final int minZ = Math.min(loc1.getBlockZ(), loc2.getBlockZ());
-		final int maxZ = Math.max(loc1.getBlockZ(), loc2.getBlockZ());
-
-		for (int x = minX; x <= maxX; ++x) {
-			for (int z = minZ; z <= maxZ; ++z) {
-				for (int y = minY; y <= maxY; ++y) {
-					locations.add(new Location(world, x, y, z));
-				}
-			}
-		}
-		return locations;
-	}
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/HandlerVoid.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/HandlerVoid.java
@@ -1,19 +1,22 @@
 package org.wensheng.juicyraspberrypie.command;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * A handler for a command that does not return a result.
  */
 public interface HandlerVoid extends Handler {
 	@Override
-	default String handle(final Instruction instruction) {
-		handleVoid(instruction);
+	default String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
+		handleVoid(sessionAttachment, instruction);
 		return "OK";
 	}
 
 	/**
 	 * Handle the instruction.
 	 *
-	 * @param instruction the instruction
+	 * @param sessionAttachment the session attachment
+	 * @param instruction       the instruction
 	 */
-	void handleVoid(Instruction instruction);
+	void handleVoid(@NotNull SessionAttachment sessionAttachment, @NotNull Instruction instruction);
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/Instruction.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/Instruction.java
@@ -2,10 +2,13 @@ package org.wensheng.juicyraspberrypie.command;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.Collectors;
@@ -88,6 +91,33 @@ public class Instruction implements Iterator<String> {
 	 */
 	public Location nextLocation() {
 		return locationParser.parse(next(), next(), next());
+	}
+
+	/**
+	 * Get the locations between the next two locations from the instruction.
+	 *
+	 * @return the locations
+	 */
+	public List<Location> nextLocationsBetween() {
+		final Location loc1 = nextLocation();
+		final Location loc2 = nextLocation();
+		final List<Location> locations = new ArrayList<>();
+		final World world = loc1.getWorld();
+		final int minX = Math.min(loc1.getBlockX(), loc2.getBlockX());
+		final int maxX = Math.max(loc1.getBlockX(), loc2.getBlockX());
+		final int minY = Math.min(loc1.getBlockY(), loc2.getBlockY());
+		final int maxY = Math.max(loc1.getBlockY(), loc2.getBlockY());
+		final int minZ = Math.min(loc1.getBlockZ(), loc2.getBlockZ());
+		final int maxZ = Math.max(loc1.getBlockZ(), loc2.getBlockZ());
+
+		for (int x = minX; x <= maxX; ++x) {
+			for (int z = minZ; z <= maxZ; ++z) {
+				for (int y = minY; y <= maxY; ++y) {
+					locations.add(new Location(world, x, y, z));
+				}
+			}
+		}
+		return locations;
 	}
 
 	/**

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/LocationRenderer.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/LocationRenderer.java
@@ -1,0 +1,31 @@
+package org.wensheng.juicyraspberrypie.command;
+
+import org.bukkit.Location;
+
+/**
+ * A renderer for locations.
+ */
+public final class LocationRenderer {
+	private LocationRenderer() {
+	}
+
+	/**
+	 * Get the location as a string from the given location.
+	 *
+	 * @param loc the location
+	 * @return the location as a string
+	 */
+	public static String getLocation(final Location loc) {
+		return loc.getX() + "," + loc.getY() + "," + loc.getZ();
+	}
+
+	/**
+	 * Get the block location as a string from the given location.
+	 *
+	 * @param loc the location
+	 * @return the block location as a string
+	 */
+	public static String getBlockLocation(final Location loc) {
+		return loc.getBlockX() + "," + loc.getBlockY() + "," + loc.getBlockZ();
+	}
+}

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/entity/EntityByPlayerNameProvider.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/entity/EntityByPlayerNameProvider.java
@@ -1,6 +1,7 @@
 package org.wensheng.juicyraspberrypie.command.entity;
 
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Instruction;
 import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 
@@ -11,25 +12,17 @@ import java.util.NoSuchElementException;
  */
 public class EntityByPlayerNameProvider implements EntityProvider {
 	/**
-	 * The session attachment associated with this handler.
-	 */
-	private final SessionAttachment attachment;
-
-	/**
 	 * Create a new entity provider by player name.
-	 *
-	 * @param attachment The session attachment to associate with this handler.
 	 */
-	public EntityByPlayerNameProvider(final SessionAttachment attachment) {
-		this.attachment = attachment;
+	public EntityByPlayerNameProvider() {
 	}
 
 	@Override
-	public Player getEntity(final Instruction instruction) {
+	public Player getEntity(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final Player player;
 		if (instruction.peek() == null) {
 			instruction.next();
-			player = attachment.getPlayer();
+			player = sessionAttachment.getPlayer();
 		} else {
 			player = instruction.nextNamedPlayer();
 		}

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/entity/EntityByUUIDProvider.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/entity/EntityByUUIDProvider.java
@@ -2,7 +2,9 @@ package org.wensheng.juicyraspberrypie.command.entity;
 
 import org.bukkit.Server;
 import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 
 import java.util.NoSuchElementException;
 import java.util.UUID;
@@ -26,7 +28,7 @@ public class EntityByUUIDProvider implements EntityProvider {
 	}
 
 	@Override
-	public Entity getEntity(final Instruction instruction) {
+	public Entity getEntity(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final UUID entityUuid = UUID.fromString(instruction.next());
 		final Entity entity = server.getEntity(entityUuid);
 		if (entity == null) {

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/entity/EntityProvider.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/entity/EntityProvider.java
@@ -1,7 +1,9 @@
 package org.wensheng.juicyraspberrypie.command.entity;
 
 import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 
 /**
  * Provides entities for use in command handlers.
@@ -10,8 +12,9 @@ public interface EntityProvider {
 	/**
 	 * Get the entity associated with the given instruction.
 	 *
-	 * @param instruction The instruction to get the entity for.
+	 * @param sessionAttachment The session attachment through which the entity may be gotten.
+	 * @param instruction       The instruction to get the entity for.
 	 * @return The entity associated with the given instruction.
 	 */
-	Entity getEntity(Instruction instruction);
+	Entity getEntity(@NotNull SessionAttachment sessionAttachment, @NotNull Instruction instruction);
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/GetPlayer.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/GetPlayer.java
@@ -1,6 +1,7 @@
 package org.wensheng.juicyraspberrypie.command.handlers;
 
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
 import org.wensheng.juicyraspberrypie.command.SessionAttachment;
@@ -10,22 +11,14 @@ import org.wensheng.juicyraspberrypie.command.SessionAttachment;
  */
 public class GetPlayer implements Handler {
 	/**
-	 * The session attachment associated with this handler.
-	 */
-	private final SessionAttachment attachment;
-
-	/**
 	 * Create a new GetPlayer event handler.
-	 *
-	 * @param attachment The session attachment to associate with this handler.
 	 */
-	public GetPlayer(final SessionAttachment attachment) {
-		this.attachment = attachment;
+	public GetPlayer() {
 	}
 
 	@Override
-	public String handle(final Instruction instruction) {
-		final Player player = attachment.getPlayer();
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
+		final Player player = sessionAttachment.getPlayer();
 		return player == null ? "(none)" : player.getName();
 	}
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/SetPlayer.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/SetPlayer.java
@@ -1,5 +1,6 @@
 package org.wensheng.juicyraspberrypie.command.handlers;
 
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
 import org.wensheng.juicyraspberrypie.command.SessionAttachment;
@@ -9,21 +10,13 @@ import org.wensheng.juicyraspberrypie.command.SessionAttachment;
  */
 public class SetPlayer implements Handler {
 	/**
-	 * The session attachment associated with this handler.
-	 */
-	private final SessionAttachment attachment;
-
-	/**
 	 * Create a new SetPlayer event handler.
-	 *
-	 * @param attachment The session attachment to associate with this handler.
 	 */
-	public SetPlayer(final SessionAttachment attachment) {
-		this.attachment = attachment;
+	public SetPlayer() {
 	}
 
 	@Override
-	public String handle(final Instruction instruction) {
-		return String.valueOf(attachment.setPlayerAndOrigin(instruction.next()));
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
+		return String.valueOf(sessionAttachment.setPlayerAndOrigin(instruction.next()));
 	}
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/chat/Post.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/chat/Post.java
@@ -1,8 +1,10 @@
 package org.wensheng.juicyraspberrypie.command.handlers.chat;
 
 import org.bukkit.Server;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.HandlerVoid;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 
 /**
  * Post a message to the chat.
@@ -24,7 +26,7 @@ public class Post implements HandlerVoid {
 	}
 
 	@Override
-	public void handleVoid(final Instruction instruction) {
+	public void handleVoid(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final String message = instruction.allArguments();
 		server.broadcastMessage(message);
 	}

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/console/PerformCommand.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/console/PerformCommand.java
@@ -4,6 +4,7 @@ import org.bukkit.Bukkit;
 import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 
 import java.util.List;
 import java.util.Objects;
@@ -36,7 +37,7 @@ public class PerformCommand implements Handler {
 	}
 
 	@Override
-	public String handle(@NotNull final Instruction instruction) {
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final String command = instruction.allArguments();
 		if (whitelistPatterns.stream().noneMatch(pattern -> pattern.matcher(command).matches())) {
 			logger.warning("Rejected command because it is not matched by the whitelist: " + command);

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/DisableControl.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/DisableControl.java
@@ -1,8 +1,10 @@
 package org.wensheng.juicyraspberrypie.command.handlers.entity;
 
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.HandlerVoid;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 import org.wensheng.juicyraspberrypie.command.entity.ControllableEntity;
 import org.wensheng.juicyraspberrypie.command.entity.EntityByUUIDProvider;
 
@@ -32,8 +34,8 @@ public class DisableControl implements HandlerVoid {
 	}
 
 	@Override
-	public void handleVoid(final Instruction instruction) {
-		final ControllableEntity entity = new ControllableEntity(plugin, entityProvider.getEntity(instruction));
+	public void handleVoid(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
+		final ControllableEntity entity = new ControllableEntity(plugin, entityProvider.getEntity(sessionAttachment, instruction));
 		entity.disableControl();
 	}
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/EnableControl.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/EnableControl.java
@@ -1,8 +1,10 @@
 package org.wensheng.juicyraspberrypie.command.handlers.entity;
 
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.HandlerVoid;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 import org.wensheng.juicyraspberrypie.command.entity.ControllableEntity;
 import org.wensheng.juicyraspberrypie.command.entity.EntityByUUIDProvider;
 
@@ -32,8 +34,8 @@ public class EnableControl implements HandlerVoid {
 	}
 
 	@Override
-	public void handleVoid(final Instruction instruction) {
-		final ControllableEntity entity = new ControllableEntity(plugin, entityProvider.getEntity(instruction));
+	public void handleVoid(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
+		final ControllableEntity entity = new ControllableEntity(plugin, entityProvider.getEntity(sessionAttachment, instruction));
 		entity.enableControl();
 	}
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/GetDirection.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/GetDirection.java
@@ -1,8 +1,10 @@
 package org.wensheng.juicyraspberrypie.command.handlers.entity;
 
 import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 import org.wensheng.juicyraspberrypie.command.entity.EntityProvider;
 
 /**
@@ -24,8 +26,8 @@ public class GetDirection implements Handler {
 	}
 
 	@Override
-	public String handle(final Instruction instruction) {
-		final Entity entity = entityProvider.getEntity(instruction);
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
+		final Entity entity = entityProvider.getEntity(sessionAttachment, instruction);
 		return entity.getLocation().getDirection().toString();
 	}
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/GetPitch.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/GetPitch.java
@@ -1,8 +1,10 @@
 package org.wensheng.juicyraspberrypie.command.handlers.entity;
 
 import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 import org.wensheng.juicyraspberrypie.command.entity.EntityProvider;
 
 /**
@@ -24,8 +26,8 @@ public class GetPitch implements Handler {
 	}
 
 	@Override
-	public String handle(final Instruction instruction) {
-		final Entity entity = entityProvider.getEntity(instruction);
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
+		final Entity entity = entityProvider.getEntity(sessionAttachment, instruction);
 		return String.valueOf(entity.getLocation().getPitch());
 	}
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/GetPos.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/GetPos.java
@@ -1,9 +1,11 @@
 package org.wensheng.juicyraspberrypie.command.handlers.entity;
 
 import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
 import org.wensheng.juicyraspberrypie.command.LocationRenderer;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 import org.wensheng.juicyraspberrypie.command.entity.EntityProvider;
 
 /**
@@ -25,8 +27,8 @@ public class GetPos implements Handler {
 	}
 
 	@Override
-	public String handle(final Instruction instruction) {
-		final Entity entity = entityProvider.getEntity(instruction);
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
+		final Entity entity = entityProvider.getEntity(sessionAttachment, instruction);
 		return LocationRenderer.getLocation(entity.getLocation());
 	}
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/GetPos.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/GetPos.java
@@ -3,6 +3,7 @@ package org.wensheng.juicyraspberrypie.command.handlers.entity;
 import org.bukkit.entity.Entity;
 import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.LocationRenderer;
 import org.wensheng.juicyraspberrypie.command.entity.EntityProvider;
 
 /**
@@ -26,6 +27,6 @@ public class GetPos implements Handler {
 	@Override
 	public String handle(final Instruction instruction) {
 		final Entity entity = entityProvider.getEntity(instruction);
-		return getLocation(entity.getLocation());
+		return LocationRenderer.getLocation(entity.getLocation());
 	}
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/GetRotation.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/GetRotation.java
@@ -1,8 +1,10 @@
 package org.wensheng.juicyraspberrypie.command.handlers.entity;
 
 import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 import org.wensheng.juicyraspberrypie.command.entity.EntityProvider;
 
 /**
@@ -24,8 +26,8 @@ public class GetRotation implements Handler {
 	}
 
 	@Override
-	public String handle(final Instruction instruction) {
-		final Entity entity = entityProvider.getEntity(instruction);
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
+		final Entity entity = entityProvider.getEntity(sessionAttachment, instruction);
 		return String.valueOf(entity.getLocation().getYaw());
 	}
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/GetTile.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/GetTile.java
@@ -3,6 +3,7 @@ package org.wensheng.juicyraspberrypie.command.handlers.entity;
 import org.bukkit.entity.Entity;
 import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.LocationRenderer;
 import org.wensheng.juicyraspberrypie.command.entity.EntityProvider;
 
 /**
@@ -26,6 +27,6 @@ public class GetTile implements Handler {
 	@Override
 	public String handle(final Instruction instruction) {
 		final Entity entity = entityProvider.getEntity(instruction);
-		return getBlockLocation(entity.getLocation());
+		return LocationRenderer.getBlockLocation(entity.getLocation());
 	}
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/GetTile.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/GetTile.java
@@ -1,9 +1,11 @@
 package org.wensheng.juicyraspberrypie.command.handlers.entity;
 
 import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
 import org.wensheng.juicyraspberrypie.command.LocationRenderer;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 import org.wensheng.juicyraspberrypie.command.entity.EntityProvider;
 
 /**
@@ -25,8 +27,8 @@ public class GetTile implements Handler {
 	}
 
 	@Override
-	public String handle(final Instruction instruction) {
-		final Entity entity = entityProvider.getEntity(instruction);
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
+		final Entity entity = entityProvider.getEntity(sessionAttachment, instruction);
 		return LocationRenderer.getBlockLocation(entity.getLocation());
 	}
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/Remove.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/Remove.java
@@ -2,8 +2,10 @@ package org.wensheng.juicyraspberrypie.command.handlers.entity;
 
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.HandlerVoid;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 import org.wensheng.juicyraspberrypie.command.entity.EntityByUUIDProvider;
 
 /**
@@ -25,8 +27,8 @@ public class Remove implements HandlerVoid {
 	}
 
 	@Override
-	public void handleVoid(final Instruction instruction) {
-		final Entity entity = entityProvider.getEntity(instruction);
+	public void handleVoid(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
+		final Entity entity = entityProvider.getEntity(sessionAttachment, instruction);
 		if (!(entity instanceof Player)) {
 			entity.remove();
 		}

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/SetDirection.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/SetDirection.java
@@ -3,8 +3,10 @@ package org.wensheng.juicyraspberrypie.command.handlers.entity;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Mob;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.HandlerVoid;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 import org.wensheng.juicyraspberrypie.command.entity.EntityProvider;
 
 /**
@@ -26,8 +28,8 @@ public class SetDirection implements HandlerVoid {
 	}
 
 	@Override
-	public void handleVoid(final Instruction instruction) {
-		final Entity entity = entityProvider.getEntity(instruction);
+	public void handleVoid(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
+		final Entity entity = entityProvider.getEntity(sessionAttachment, instruction);
 		final Location loc = instruction.nextLocation();
 		final Location entityLoc = entity.getLocation();
 		final Location target = entityLoc.setDirection(loc.toVector());

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/SetPitch.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/SetPitch.java
@@ -2,8 +2,10 @@ package org.wensheng.juicyraspberrypie.command.handlers.entity;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.HandlerVoid;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 import org.wensheng.juicyraspberrypie.command.entity.EntityProvider;
 
 /**
@@ -25,8 +27,8 @@ public class SetPitch implements HandlerVoid {
 	}
 
 	@Override
-	public void handleVoid(final Instruction instruction) {
-		final Entity entity = entityProvider.getEntity(instruction);
+	public void handleVoid(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
+		final Entity entity = entityProvider.getEntity(sessionAttachment, instruction);
 		final float pitch = Float.parseFloat(instruction.next());
 		final Location entityLoc = entity.getLocation();
 		entityLoc.setPitch(pitch);

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/SetPos.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/SetPos.java
@@ -2,8 +2,10 @@ package org.wensheng.juicyraspberrypie.command.handlers.entity;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.HandlerVoid;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 import org.wensheng.juicyraspberrypie.command.entity.EntityProvider;
 
 /**
@@ -25,8 +27,8 @@ public class SetPos implements HandlerVoid {
 	}
 
 	@Override
-	public void handleVoid(final Instruction instruction) {
-		final Entity entity = entityProvider.getEntity(instruction);
+	public void handleVoid(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
+		final Entity entity = entityProvider.getEntity(sessionAttachment, instruction);
 		final Location loc = instruction.nextLocation();
 		final Location entityLoc = entity.getLocation();
 		loc.setPitch(entityLoc.getPitch());

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/SetRotation.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/SetRotation.java
@@ -3,8 +3,10 @@ package org.wensheng.juicyraspberrypie.command.handlers.entity;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Mob;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.HandlerVoid;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 import org.wensheng.juicyraspberrypie.command.entity.EntityProvider;
 
 /**
@@ -26,8 +28,8 @@ public class SetRotation implements HandlerVoid {
 	}
 
 	@Override
-	public void handleVoid(final Instruction instruction) {
-		final Entity entity = entityProvider.getEntity(instruction);
+	public void handleVoid(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
+		final Entity entity = entityProvider.getEntity(sessionAttachment, instruction);
 		final float yaw = Float.parseFloat(instruction.next());
 		final Location entityLoc = entity.getLocation();
 		entityLoc.setYaw(yaw);

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/SetTile.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/SetTile.java
@@ -2,8 +2,10 @@ package org.wensheng.juicyraspberrypie.command.handlers.entity;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.HandlerVoid;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 import org.wensheng.juicyraspberrypie.command.entity.EntityProvider;
 
 /**
@@ -25,8 +27,8 @@ public class SetTile implements HandlerVoid {
 	}
 
 	@Override
-	public void handleVoid(final Instruction instruction) {
-		final Entity entity = entityProvider.getEntity(instruction);
+	public void handleVoid(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
+		final Entity entity = entityProvider.getEntity(sessionAttachment, instruction);
 		final Location loc = instruction.nextBlockLocation();
 		final Location entityLoc = entity.getLocation();
 		loc.setPitch(entityLoc.getPitch());

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/WalkTo.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/WalkTo.java
@@ -2,8 +2,10 @@ package org.wensheng.juicyraspberrypie.command.handlers.entity;
 
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Mob;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.HandlerVoid;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 import org.wensheng.juicyraspberrypie.command.entity.EntityByUUIDProvider;
 
 /**
@@ -25,8 +27,8 @@ public class WalkTo implements HandlerVoid {
 	}
 
 	@Override
-	public void handleVoid(final Instruction instruction) {
-		final Entity entity = entityProvider.getEntity(instruction);
+	public void handleVoid(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
+		final Entity entity = entityProvider.getEntity(sessionAttachment, instruction);
 		if (entity instanceof final Mob mob) {
 			mob.getPathfinder().moveTo(instruction.nextLocation());
 		}

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/Clear.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/Clear.java
@@ -1,8 +1,10 @@
 package org.wensheng.juicyraspberrypie.command.handlers.events;
 
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.HandlerVoid;
 import org.wensheng.juicyraspberrypie.command.Instruction;
 import org.wensheng.juicyraspberrypie.command.Registry;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 
 /**
  * Clear all event queues.
@@ -23,7 +25,7 @@ public class Clear implements HandlerVoid {
 	}
 
 	@Override
-	public void handleVoid(final Instruction instruction) {
+	public void handleVoid(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		registry.getHandlers().stream()
 				.filter(handler -> handler instanceof EventQueue<?>)
 				.map(handler -> (EventQueue<?>) handler)

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/EventQueue.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/EventQueue.java
@@ -3,7 +3,6 @@ package org.wensheng.juicyraspberrypie.command.handlers.events;
 import org.bukkit.event.Event;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.Plugin;
-import org.wensheng.juicyraspberrypie.command.Handler;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -13,7 +12,7 @@ import java.util.Deque;
  *
  * @param <T> The type of event to queue.
  */
-public abstract class EventQueue<T extends Event> implements Handler, Listener {
+public abstract class EventQueue<T extends Event> implements Listener {
 	/**
 	 * The event queue.
 	 */

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/block/Hits.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/block/Hits.java
@@ -10,6 +10,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.LocationRenderer;
 import org.wensheng.juicyraspberrypie.command.handlers.events.EventQueue;
 
 import java.util.EnumSet;
@@ -47,7 +48,7 @@ public class Hits extends EventQueue<PlayerInteractEvent> {
 			final Block block = event.getClickedBlock();
 			if (block != null) {
 				final Location loc = block.getLocation();
-				stringBuilder.append(getBlockLocation(loc)).append(',').append(event.getBlockFace().name()).append(',').append(event.getPlayer().getUniqueId());
+				stringBuilder.append(LocationRenderer.getBlockLocation(loc)).append(',').append(event.getBlockFace().name()).append(',').append(event.getPlayer().getUniqueId());
 			} else {
 				stringBuilder.append("0,0,0,Fail,0");
 			}

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/block/Hits.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/block/Hits.java
@@ -10,6 +10,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
+import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
 import org.wensheng.juicyraspberrypie.command.LocationRenderer;
 import org.wensheng.juicyraspberrypie.command.SessionAttachment;
@@ -22,7 +23,7 @@ import java.util.Set;
  * Get one block hit event from the queue.
  */
 @SuppressWarnings("PMD.ShortClassName")
-public class Hits extends EventQueue<PlayerInteractEvent> {
+public class Hits extends EventQueue<PlayerInteractEvent> implements Handler {
 	/**
 	 * The set of tools that can detect block breaks.
 	 */

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/block/Hits.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/block/Hits.java
@@ -46,7 +46,7 @@ public class Hits extends EventQueue<PlayerInteractEvent> implements Handler {
 	@Override
 	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final StringBuilder stringBuilder = new StringBuilder();
-		while (isQueueEmpty()) {
+		while (!isQueueEmpty()) {
 			final PlayerInteractEvent event = pollEvent();
 			final Block block = event.getClickedBlock();
 			if (block != null) {

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/block/Hits.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/block/Hits.java
@@ -9,8 +9,10 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Instruction;
 import org.wensheng.juicyraspberrypie.command.LocationRenderer;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 import org.wensheng.juicyraspberrypie.command.handlers.events.EventQueue;
 
 import java.util.EnumSet;
@@ -41,7 +43,7 @@ public class Hits extends EventQueue<PlayerInteractEvent> {
 	}
 
 	@Override
-	public String handle(final Instruction instruction) {
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final StringBuilder stringBuilder = new StringBuilder();
 		while (isQueueEmpty()) {
 			final PlayerInteractEvent event = pollEvent();

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/chat/Posts.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/chat/Posts.java
@@ -5,7 +5,9 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 import org.wensheng.juicyraspberrypie.command.handlers.events.EventQueue;
 
 /**
@@ -22,7 +24,7 @@ public class Posts extends EventQueue<AsyncPlayerChatEvent> {
 	}
 
 	@Override
-	public String handle(final Instruction instruction) {
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final StringBuilder stringBuilder = new StringBuilder();
 		while (isQueueEmpty()) {
 			final AsyncPlayerChatEvent event = pollEvent();

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/chat/Posts.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/chat/Posts.java
@@ -6,6 +6,7 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
+import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
 import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 import org.wensheng.juicyraspberrypie.command.handlers.events.EventQueue;
@@ -13,7 +14,7 @@ import org.wensheng.juicyraspberrypie.command.handlers.events.EventQueue;
 /**
  * Get one chat event from the queue.
  */
-public class Posts extends EventQueue<AsyncPlayerChatEvent> {
+public class Posts extends EventQueue<AsyncPlayerChatEvent> implements Handler {
 	/**
 	 * Create a new Posts event handler.
 	 *

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/chat/Posts.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/chat/Posts.java
@@ -27,7 +27,7 @@ public class Posts extends EventQueue<AsyncPlayerChatEvent> implements Handler {
 	@Override
 	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final StringBuilder stringBuilder = new StringBuilder();
-		while (isQueueEmpty()) {
+		while (!isQueueEmpty()) {
 			final AsyncPlayerChatEvent event = pollEvent();
 			final Player player = event.getPlayer();
 			stringBuilder.append(player.getName()).append(',').append(player.getUniqueId()).append(',').append(event.getMessage());

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/projectile/Hits.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/projectile/Hits.java
@@ -33,7 +33,7 @@ public class Hits extends EventQueue<ProjectileHitEvent> implements Handler {
 	@Override
 	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final StringBuilder stringBuilder = new StringBuilder();
-		while (isQueueEmpty()) {
+		while (!isQueueEmpty()) {
 			final ProjectileHitEvent event = pollEvent();
 			final Arrow arrow = (Arrow) event.getEntity();
 			final Player player = (Player) arrow.getShooter();

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/projectile/Hits.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/projectile/Hits.java
@@ -9,8 +9,10 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Instruction;
 import org.wensheng.juicyraspberrypie.command.LocationRenderer;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 import org.wensheng.juicyraspberrypie.command.handlers.events.EventQueue;
 
 /**
@@ -28,7 +30,7 @@ public class Hits extends EventQueue<ProjectileHitEvent> {
 	}
 
 	@Override
-	public String handle(final Instruction instruction) {
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final StringBuilder stringBuilder = new StringBuilder();
 		while (isQueueEmpty()) {
 			final ProjectileHitEvent event = pollEvent();

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/projectile/Hits.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/projectile/Hits.java
@@ -10,6 +10,7 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.plugin.Plugin;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.LocationRenderer;
 import org.wensheng.juicyraspberrypie.command.handlers.events.EventQueue;
 
 /**
@@ -36,7 +37,7 @@ public class Hits extends EventQueue<ProjectileHitEvent> {
 			if (player != null) {
 				final Block block = arrow.getLocation().getBlock();
 				final Location loc = block.getLocation();
-				stringBuilder.append(getBlockLocation(loc)).append(',').append(player.getUniqueId()).append(',');
+				stringBuilder.append(LocationRenderer.getBlockLocation(loc)).append(',').append(player.getUniqueId()).append(',');
 				final Entity hitEntity = event.getHitEntity();
 				if (hitEntity != null) {
 					stringBuilder.append(hitEntity.getUniqueId());

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/projectile/Hits.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/events/projectile/Hits.java
@@ -10,6 +10,7 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
+import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
 import org.wensheng.juicyraspberrypie.command.LocationRenderer;
 import org.wensheng.juicyraspberrypie.command.SessionAttachment;
@@ -19,7 +20,7 @@ import org.wensheng.juicyraspberrypie.command.handlers.events.EventQueue;
  * Get one projectile hit event from the queue.
  */
 @SuppressWarnings("PMD.ShortClassName")
-public class Hits extends EventQueue<ProjectileHitEvent> {
+public class Hits extends EventQueue<ProjectileHitEvent> implements Handler {
 	/**
 	 * Create a new Hits event handler.
 	 *

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/player/PerformCommand.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/player/PerformCommand.java
@@ -1,5 +1,6 @@
 package org.wensheng.juicyraspberrypie.command.handlers.player;
 
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
 import org.wensheng.juicyraspberrypie.command.SessionAttachment;
@@ -9,21 +10,13 @@ import org.wensheng.juicyraspberrypie.command.SessionAttachment;
  */
 public class PerformCommand implements Handler {
 	/**
-	 * The session attachment associated with this handler.
-	 */
-	private final SessionAttachment attachment;
-
-	/**
 	 * Create a new PerformCommand event handler.
-	 *
-	 * @param attachment The session attachment to associate with this handler.
 	 */
-	public PerformCommand(final SessionAttachment attachment) {
-		this.attachment = attachment;
+	public PerformCommand() {
 	}
 
 	@Override
-	public String handle(final Instruction instruction) {
-		return String.valueOf(attachment.getPlayer().performCommand(instruction.allArguments()));
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
+		return String.valueOf(sessionAttachment.getPlayer().performCommand(instruction.allArguments()));
 	}
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/GetBlock.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/GetBlock.java
@@ -1,7 +1,9 @@
 package org.wensheng.juicyraspberrypie.command.handlers.world;
 
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 
 /**
  * Get the type of block at a given location.
@@ -14,7 +16,7 @@ public class GetBlock implements Handler {
 	}
 
 	@Override
-	public String handle(final Instruction instruction) {
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		return instruction.nextLocation().getBlock().getType().name();
 	}
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/GetBlockWithData.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/GetBlockWithData.java
@@ -1,8 +1,10 @@
 package org.wensheng.juicyraspberrypie.command.handlers.world;
 
 import org.bukkit.block.Block;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 
 /**
  * Get the type and data of a block at a given location.
@@ -15,7 +17,7 @@ public class GetBlockWithData implements Handler {
 	}
 
 	@Override
-	public String handle(final Instruction instruction) {
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final Block block = instruction.nextLocation().getBlock();
 		return block.getType().name() + "," + block.getBlockData();
 	}

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/GetBlocks.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/GetBlocks.java
@@ -1,6 +1,5 @@
 package org.wensheng.juicyraspberrypie.command.handlers.world;
 
-import org.bukkit.Location;
 import org.bukkit.Material;
 import org.codehaus.plexus.util.StringUtils;
 import org.wensheng.juicyraspberrypie.command.Handler;
@@ -20,9 +19,7 @@ public class GetBlocks implements Handler {
 
 	@Override
 	public String handle(final Instruction instruction) {
-		final Location pos1 = instruction.nextLocation();
-		final Location pos2 = instruction.nextLocation();
-		final List<Material> list = getLocationsBetween(pos1, pos2).stream().map(loc -> loc.getBlock().getType()).toList();
+		final List<Material> list = instruction.nextLocationsBetween().stream().map(loc -> loc.getBlock().getType()).toList();
 		return StringUtils.join(list.iterator(), ",");
 	}
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/GetBlocks.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/GetBlocks.java
@@ -2,8 +2,10 @@ package org.wensheng.juicyraspberrypie.command.handlers.world;
 
 import org.bukkit.Material;
 import org.codehaus.plexus.util.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 
 import java.util.List;
 
@@ -18,7 +20,7 @@ public class GetBlocks implements Handler {
 	}
 
 	@Override
-	public String handle(final Instruction instruction) {
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final List<Material> list = instruction.nextLocationsBetween().stream().map(loc -> loc.getBlock().getType()).toList();
 		return StringUtils.join(list.iterator(), ",");
 	}

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/GetHeight.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/GetHeight.java
@@ -1,8 +1,10 @@
 package org.wensheng.juicyraspberrypie.command.handlers.world;
 
 import org.bukkit.Location;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 
 /**
  * Gets the height of the highest block at a given location.
@@ -15,7 +17,7 @@ public class GetHeight implements Handler {
 	}
 
 	@Override
-	public String handle(final Instruction instruction) {
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final Location loc = instruction.nextLocation();
 		return String.valueOf(loc.getWorld().getHighestBlockYAt(loc));
 	}

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/GetNearbyEntities.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/GetNearbyEntities.java
@@ -2,8 +2,10 @@ package org.wensheng.juicyraspberrypie.command.handlers.world;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 
 import java.util.Collection;
 
@@ -19,7 +21,7 @@ public class GetNearbyEntities implements Handler {
 
 	@Override
 	@SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
-	public String handle(final Instruction instruction) {
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final Location loc = instruction.nextLocation();
 		final double nearbyDistance = instruction.hasNext() ? Double.parseDouble(instruction.next()) : 10.0;
 		final Collection<Entity> nearbyEntities = loc.getNearbyEntities(nearbyDistance, 5.0, nearbyDistance);

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/GetPlayerId.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/GetPlayerId.java
@@ -1,8 +1,10 @@
 package org.wensheng.juicyraspberrypie.command.handlers.world;
 
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 
 /**
  * Get the UUID of a given player.
@@ -15,7 +17,7 @@ public class GetPlayerId implements Handler {
 	}
 
 	@Override
-	public String handle(final Instruction instruction) {
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final Player player = instruction.nextNamedPlayer();
 		if (player != null) {
 			return player.getUniqueId().toString();

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/GetPlayerIds.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/GetPlayerIds.java
@@ -2,8 +2,10 @@ package org.wensheng.juicyraspberrypie.command.handlers.world;
 
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 
 /**
  * Get the names and UUIDs of all online players.
@@ -24,7 +26,7 @@ public class GetPlayerIds implements Handler {
 	}
 
 	@Override
-	public String handle(final Instruction instruction) {
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final StringBuilder bdr = new StringBuilder();
 		for (final Player p : server.getOnlinePlayers()) {
 			bdr.append(p.getName()).append(',').append(p.getUniqueId()).append('|');

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/IsBlockPassable.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/IsBlockPassable.java
@@ -1,8 +1,10 @@
 package org.wensheng.juicyraspberrypie.command.handlers.world;
 
 import org.bukkit.Location;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 
 /**
  * Checks if a block is passable at a given location.
@@ -15,7 +17,7 @@ public class IsBlockPassable implements Handler {
 	}
 
 	@Override
-	public String handle(final Instruction instruction) {
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final Location loc = instruction.nextLocation();
 		return String.valueOf(loc.getBlock().isPassable());
 	}

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/SetBlock.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/SetBlock.java
@@ -5,8 +5,10 @@ import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Directional;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.HandlerVoid;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 
 /**
  * Set a block at a location.
@@ -19,7 +21,7 @@ public class SetBlock implements HandlerVoid {
 	}
 
 	@Override
-	public void handleVoid(final Instruction instruction) {
+	public void handleVoid(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final Location loc = instruction.nextLocation();
 		Material material = Material.matchMaterial(instruction.next());
 		if (material == null) {

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/SetBlocks.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/SetBlocks.java
@@ -3,8 +3,10 @@ package org.wensheng.juicyraspberrypie.command.handlers.world;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.HandlerVoid;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 
 import java.util.List;
 
@@ -20,7 +22,7 @@ public class SetBlocks extends SetBlock implements HandlerVoid {
 	}
 
 	@Override
-	public void handleVoid(final Instruction instruction) {
+	public void handleVoid(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final List<Location> locations = instruction.nextLocationsBetween();
 		final Material mat = Material.matchMaterial(instruction.next());
 		final Material material = mat == null ? Material.valueOf("SANDSTONE") : mat;

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/SetBlocks.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/SetBlocks.java
@@ -6,6 +6,8 @@ import org.bukkit.block.BlockFace;
 import org.wensheng.juicyraspberrypie.command.HandlerVoid;
 import org.wensheng.juicyraspberrypie.command.Instruction;
 
+import java.util.List;
+
 /**
  * Set blocks between two locations
  */
@@ -19,13 +21,12 @@ public class SetBlocks extends SetBlock implements HandlerVoid {
 
 	@Override
 	public void handleVoid(final Instruction instruction) {
-		final Location loc1 = instruction.nextLocation();
-		final Location loc2 = instruction.nextLocation();
+		final List<Location> locations = instruction.nextLocationsBetween();
 		final Material mat = Material.matchMaterial(instruction.next());
 		final Material material = mat == null ? Material.valueOf("SANDSTONE") : mat;
 		final int facing = instruction.hasNext() ? Integer.parseInt(instruction.next()) : 0;
 		final BlockFace blockFace = BlockFace.values()[facing];
 
-		getLocationsBetween(loc1, loc2).forEach(loc -> updateBlock(loc, material, blockFace));
+		locations.forEach(loc -> updateBlock(loc, material, blockFace));
 	}
 }

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/SetPowered.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/SetPowered.java
@@ -7,8 +7,10 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Container;
 import org.bukkit.block.data.type.Switch;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.HandlerVoid;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 
 import java.util.NoSuchElementException;
 
@@ -23,7 +25,7 @@ public class SetPowered implements HandlerVoid {
 	}
 
 	@Override
-	public void handleVoid(final Instruction instruction) {
+	public void handleVoid(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final Location loc = instruction.nextLocation();
 		final Block block = loc.getBlock();
 		if (block.getBlockData() instanceof final Switch powerableSwitch) {

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/SetSign.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/SetSign.java
@@ -6,8 +6,10 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.Sign;
 import org.bukkit.block.data.BlockData;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.HandlerVoid;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 
 /**
  * Sets a sign at the specified location with specified data.
@@ -28,7 +30,7 @@ public class SetSign implements HandlerVoid {
 
 	@Override
 	@SuppressWarnings("PMD.PrematureDeclaration")
-	public void handleVoid(final Instruction instruction) {
+	public void handleVoid(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final Location loc = instruction.nextLocation();
 		Material material = Material.matchMaterial(instruction.next());
 		if (material == null) {

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/SpawnEntity.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/SpawnEntity.java
@@ -3,8 +3,10 @@ package org.wensheng.juicyraspberrypie.command.handlers.world;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.Handler;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 
 import java.util.Locale;
 
@@ -20,7 +22,7 @@ public class SpawnEntity implements Handler {
 
 	@Override
 	@SuppressWarnings("PMD.AvoidCatchingGenericException")
-	public String handle(final Instruction instruction) {
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final Location loc = instruction.nextLocation();
 		EntityType entityType;
 		try {

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/SpawnParticle.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/SpawnParticle.java
@@ -2,8 +2,10 @@ package org.wensheng.juicyraspberrypie.command.handlers.world;
 
 import org.bukkit.Location;
 import org.bukkit.Particle;
+import org.jetbrains.annotations.NotNull;
 import org.wensheng.juicyraspberrypie.command.HandlerVoid;
 import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
 
 import java.util.Locale;
 
@@ -20,7 +22,7 @@ public class SpawnParticle implements HandlerVoid {
 
 	@Override
 	@SuppressWarnings("PMD.AvoidCatchingGenericException")
-	public void handleVoid(final Instruction instruction) {
+	public void handleVoid(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final Location loc = instruction.nextLocation();
 		Particle particle;
 		try {


### PR DESCRIPTION
To allow other plugins (like ReQuest) to register commands, it would be much more convenient if there's only a single Registry instance; right now each RemoteSession instantiates a separate Registry, because some Handlers have session-specific state (like the current Player, and EventQueues). (Without this change, plugins would have to submit CommandHandlerFactories.)

### general design cleanup

* Move `Handler#get[Block]Location()` to new `LocationRenderer` class
* Move `Handler#getLocationsBetween()` to `Instruction#nextLocationsBetween()`
* `EventHandler` doesn't have to implement `Handler`  

These methods aren't used by Handler clients, but instead are used by Handler implementations as helpers; there's no need to be able to override the default methods, and their inclusion waters down the Handler interface.  

### refactoring towards a single Registry instance, part 1

* Pass `SessionAttachment` into `Handler[Void].handle[Void]()`

### fixes

Before attacking part 2, I noticed that polling (for chat messages) has been broken: No events are ever returned because the refactored loop condition is inverted.
The manual tests in https://github.com/ResilientGroup/WorldTemplates/blob/ef63871e7dc15940ceb960a138d1287120e32f58/dev/python/Jupyter/tests/chat.ipynb would have uncovered this\!  

<!-- BEGIN Global settings -->

---
<!-- Git and GitHub -->
- [X] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [X] Include a human-readable description of what the pull request is trying to accomplish
- [X] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [X] Steps for the reviewer(s) on how they can manually QA the changes:
  - [X] Run the Jupyter notebook tests
- [ ] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [ ] No (significant) changes to production code
---
<!-- Documentation -->
- [X] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [X] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] ~~These ReWiki pages are affected by this change and will be adapted:~~
<!-- END Global settings -->
---
<!-- Support matrix -->
- [X] The change is unrelated to Minecraft
- [ ] Works in Java edition
- [ ] Works in Bedrock edition