### PR TITLE
TASK-4751 the block data is now sent in a cleaner format, to prevent …

### DIFF
--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/GetBlockWithData.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/GetBlockWithData.java
@@ -19,6 +19,16 @@ public class GetBlockWithData implements Handler {
 	@Override
 	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final Block block = instruction.nextLocation().getBlock();
-		return block.getType().name() + "," + block.getBlockData();
+		return block.getType().name() + "," + getBlockDataStripped(block);
+	}
+
+	private static @NotNull String getBlockDataStripped(final Block block) {
+		final String data = block.getBlockData().getAsString();
+		final int start = data.indexOf('[');
+		final int end = data.indexOf(']');
+		if (start == -1 || end == -1) {
+			return "";
+		}
+		return data.substring(start + 1, end);
 	}
 }


### PR DESCRIPTION
…wrong parsing
https://github.com/ResilientGroup/mcpi/pull/11

<!-- BEGIN Global settings -->
<!-- TODO: Please describe your changes here. -->

---
<!-- Git and GitHub -->
- [x] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [x] Include a human-readable description of what the pull request is trying to accomplish
- [x] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
- [ ] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [ ] No (significant) changes to production code
---
<!-- Documentation -->
- [ ] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted:
<!-- END Global settings -->
---
<!-- Support matrix -->
- [ ] The change is unrelated to Minecraft
- [ ] Works in Java edition
- [ ] Works in Bedrock edition
