### PR TITLE
bump MavenSetup version to 1.9.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    uses: ResilientGroup/MavenSetup/.github/workflows/build.yml@1.7.4
+    uses: ResilientGroup/MavenSetup/.github/workflows/build.yml@1.9.0
     with:
       javadoc-project-name: JuicyRaspberryPie
     secrets: inherit

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>works.reload</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.8.0</version>
+		<version>1.9.0</version>
 		<relativePath/>
 	</parent>
 
@@ -17,7 +17,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>2.1.12</revision>
+		<revision>2.1.13</revision>
 		<changelist>-SNAPSHOT</changelist>
 	</properties>
 

--- a/src/main/java/org/wensheng/juicyraspberrypie/JuicyRaspberryPie.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/JuicyRaspberryPie.java
@@ -57,7 +57,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-@SuppressWarnings("PMD.CommentRequired")
+@SuppressWarnings({"PMD.CommentRequired", "PMD.AvoidSynchronizedStatement"})
 public class JuicyRaspberryPie extends JavaPlugin implements Listener {
 	private final Logger logger = Logger.getLogger("Minecraft");
 

--- a/src/main/java/org/wensheng/juicyraspberrypie/RemoteSession.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/RemoteSession.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-@SuppressWarnings("PMD.CommentRequired")
+@SuppressWarnings({"PMD.CommentRequired", "PMD.AvoidSynchronizedStatement"})
 class RemoteSession {
 	private static final int MAX_COMMANDS_PER_TICK = 9000;
 

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/SpawnEntity.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/SpawnEntity.java
@@ -21,13 +21,13 @@ public class SpawnEntity implements Handler {
 	}
 
 	@Override
-	@SuppressWarnings("PMD.AvoidCatchingGenericException")
+	@SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.LocalVariableCouldBeFinal"})
 	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final Location loc = instruction.nextLocation();
 		EntityType entityType;
 		try {
 			entityType = EntityType.valueOf(instruction.next().toUpperCase(Locale.ROOT));
-		} catch (Exception exc) {
+		} catch (final Exception exc) {
 			entityType = EntityType.valueOf("COW");
 		}
 		final Entity entity = loc.getWorld().spawnEntity(loc, entityType);

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/SpawnParticle.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/world/SpawnParticle.java
@@ -21,13 +21,13 @@ public class SpawnParticle implements HandlerVoid {
 	}
 
 	@Override
-	@SuppressWarnings("PMD.AvoidCatchingGenericException")
+	@SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.LocalVariableCouldBeFinal"})
 	public void handleVoid(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
 		final Location loc = instruction.nextLocation();
 		Particle particle;
 		try {
 			particle = Particle.valueOf(instruction.next().toUpperCase(Locale.ROOT));
-		} catch (Exception exc) {
+		} catch (final Exception exc) {
 			particle = Particle.valueOf("EXPLOSION_NORMAL");
 		}
 		final int count;


### PR DESCRIPTION
<!-- BEGIN Global settings -->
<!-- TODO: Please describe your changes here. -->

---
<!-- Git and GitHub -->
- [ ] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [x] Include a human-readable description of what the pull request is trying to accomplish
- [x] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
- [ ] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [ ] No (significant) changes to production code
---
<!-- Documentation -->
- [ ] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted:
<!-- END Global settings -->
---
<!-- Support matrix -->
- [ ] The change is unrelated to Minecraft
- [ ] Works in Java edition
- [ ] Works in Bedrock edition
