### PR TITLE
TASK-4944 implemented get_held_item

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>2.1.14</revision>
+		<revision>2.1.15</revision>
 		<changelist>-SNAPSHOT</changelist>
 	</properties>
 

--- a/src/main/java/org/wensheng/juicyraspberrypie/JuicyRaspberryPie.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/JuicyRaspberryPie.java
@@ -14,6 +14,7 @@ import org.wensheng.juicyraspberrypie.command.handlers.chat.Post;
 import org.wensheng.juicyraspberrypie.command.handlers.entity.DisableControl;
 import org.wensheng.juicyraspberrypie.command.handlers.entity.EnableControl;
 import org.wensheng.juicyraspberrypie.command.handlers.entity.GetDirection;
+import org.wensheng.juicyraspberrypie.command.handlers.entity.GetHeldItem;
 import org.wensheng.juicyraspberrypie.command.handlers.entity.GetPitch;
 import org.wensheng.juicyraspberrypie.command.handlers.entity.GetPos;
 import org.wensheng.juicyraspberrypie.command.handlers.entity.GetRotation;
@@ -288,6 +289,8 @@ public class JuicyRaspberryPie extends JavaPlugin implements Listener {
 		registry.register("entity.setPos", new SetPos(entityProvider));
 		registry.register("player.getDirection", new GetDirection(playerEntityProvider));
 		registry.register("entity.getDirection", new GetDirection(entityProvider));
+		registry.register("player.getHeldItem", new GetHeldItem(playerEntityProvider));
+		registry.register("entity.getHeldItem", new GetHeldItem(entityProvider));
 		registry.register("player.setDirection", new SetDirection(playerEntityProvider));
 		registry.register("entity.setDirection", new SetDirection(entityProvider));
 		registry.register("player.getRotation", new GetRotation(playerEntityProvider));

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/GetHeldItem.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/handlers/entity/GetHeldItem.java
@@ -1,0 +1,53 @@
+package org.wensheng.juicyraspberrypie.command.handlers.entity;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
+import org.wensheng.juicyraspberrypie.command.Handler;
+import org.wensheng.juicyraspberrypie.command.Instruction;
+import org.wensheng.juicyraspberrypie.command.SessionAttachment;
+import org.wensheng.juicyraspberrypie.command.entity.EntityProvider;
+
+/**
+ * Get the item held by an entity.
+ */
+public class GetHeldItem implements Handler {
+	/**
+	 * The entity provider associated with this handler.
+	 */
+	private final EntityProvider entityProvider;
+
+	/**
+	 * Create a new GetHeldItem event handler.
+	 *
+	 * @param entityProvider The entity provider to associate with this handler.
+	 */
+	public GetHeldItem(final EntityProvider entityProvider) {
+		this.entityProvider = entityProvider;
+	}
+
+	@Override
+	public String handle(@NotNull final SessionAttachment sessionAttachment, @NotNull final Instruction instruction) {
+		final Entity entity = entityProvider.getEntity(sessionAttachment, instruction);
+		if (entity instanceof final LivingEntity living) {
+			final EntityEquipment equipment = living.getEquipment();
+			if (equipment != null) {
+				final ItemStack itemInMainHand = equipment.getItemInMainHand();
+				return itemInMainHand.getType().name() + getCustomModelData(itemInMainHand);
+			}
+		}
+		return Material.AIR.name();
+	}
+
+	private static String getCustomModelData(final ItemStack itemInMainHand) {
+		final ItemMeta itemMeta = itemInMainHand.getItemMeta();
+		if (itemMeta == null || !itemMeta.hasCustomModelData()) {
+			return "";
+		}
+		return "," + itemMeta.getCustomModelData();
+	}
+}


### PR DESCRIPTION
https://github.com/ResilientGroup/mcpi/pull/12
<!-- BEGIN Global settings -->
<!-- TODO: Please describe your changes here. -->

---
<!-- Git and GitHub -->
- [x] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [x] Include a human-readable description of what the pull request is trying to accomplish
- [x] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
- [ ] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [ ] No (significant) changes to production code
---
<!-- Documentation -->
- [ ] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted:
<!-- END Global settings -->
---
<!-- Support matrix -->
- [ ] The change is unrelated to Minecraft
- [ ] Works in Java edition
- [ ] Works in Bedrock edition
