### PR TITLE
TASK-4964 fixed controlled mobs start acting normal again when chunks…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>2.1.16</revision>
+		<revision>2.1.17</revision>
 		<changelist>-SNAPSHOT</changelist>
 	</properties>
 

--- a/src/main/java/org/wensheng/juicyraspberrypie/JuicyRaspberryPie.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/JuicyRaspberryPie.java
@@ -42,6 +42,7 @@ import org.wensheng.juicyraspberrypie.command.handlers.world.SetPowered;
 import org.wensheng.juicyraspberrypie.command.handlers.world.SetSign;
 import org.wensheng.juicyraspberrypie.command.handlers.world.SpawnEntity;
 import org.wensheng.juicyraspberrypie.command.handlers.world.SpawnParticle;
+import org.wensheng.juicyraspberrypie.listener.EntityListener;
 
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
@@ -113,6 +114,7 @@ public class JuicyRaspberryPie extends JavaPlugin implements Listener {
 		this.saveDefaultConfig();
 		final int port = this.getConfig().getInt("api_port");
 		setupRegistry();
+		getServer().getPluginManager().registerEvents(new EntityListener(this), this);
 
 		//create new tcp listener thread
 		try {

--- a/src/main/java/org/wensheng/juicyraspberrypie/command/entity/ControllableEntity.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/command/entity/ControllableEntity.java
@@ -48,12 +48,27 @@ public class ControllableEntity {
 	 */
 	public void enableControl() {
 		if (entity instanceof final Mob mob) {
+			final PersistentDataContainer persistentDataContainer = mob.getPersistentDataContainer();
+			persistentDataContainer.set(new NamespacedKey(plugin, "controlled"), PersistentDataType.BOOLEAN, true);
 			if (!mob.hasAI()) {
-				mob.getPersistentDataContainer().set(new NamespacedKey(plugin, "noAI"), PersistentDataType.BOOLEAN, true);
+				persistentDataContainer.set(new NamespacedKey(plugin, "noAI"), PersistentDataType.BOOLEAN, true);
 				mob.setAI(true);
 			}
 			final MobGoals mobGoals = Bukkit.getMobGoals();
 			getGoalKeyNamespacedKeys().forEach((goalType, namespacedKey) -> mobGoals.addGoal(mob, Integer.MIN_VALUE, new EmptyGoal(namespacedKey, goalType)));
+		}
+	}
+
+	/**
+	 * Reactivate control of the entity.
+	 */
+	public void reactivateControl() {
+		if (entity instanceof final Mob mob) {
+			final PersistentDataContainer persistentDataContainer = mob.getPersistentDataContainer();
+			final Boolean controlled = persistentDataContainer.getOrDefault(new NamespacedKey(plugin, "controlled"), PersistentDataType.BOOLEAN, false);
+			if (controlled) {
+				enableControl();
+			}
 		}
 	}
 
@@ -65,6 +80,7 @@ public class ControllableEntity {
 			final MobGoals mobGoals = Bukkit.getMobGoals();
 			getGoalKeyNamespacedKeys().forEach((goalType, namespacedKey) -> mobGoals.removeGoal(mob, GoalKey.of(Mob.class, namespacedKey)));
 			final PersistentDataContainer persistentDataContainer = mob.getPersistentDataContainer();
+			persistentDataContainer.remove(new NamespacedKey(plugin, "controlled"));
 			final boolean noAI = persistentDataContainer.has(new NamespacedKey(plugin, "noAI"), PersistentDataType.BOOLEAN);
 			if (noAI) {
 				persistentDataContainer.remove(new NamespacedKey(plugin, "noAI"));

--- a/src/main/java/org/wensheng/juicyraspberrypie/listener/EntityListener.java
+++ b/src/main/java/org/wensheng/juicyraspberrypie/listener/EntityListener.java
@@ -1,0 +1,36 @@
+package org.wensheng.juicyraspberrypie.listener;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.EntitiesLoadEvent;
+import org.bukkit.plugin.Plugin;
+import org.wensheng.juicyraspberrypie.command.entity.ControllableEntity;
+
+/**
+ * Listener for entity events.
+ */
+public class EntityListener implements Listener {
+	/**
+	 * The plugin associated with this listener.
+	 */
+	private final Plugin plugin;
+
+	/**
+	 * Create a new entity listener.
+	 * @param plugin The plugin to associate with this listener.
+	 */
+	public EntityListener(final Plugin plugin) {
+		this.plugin = plugin;
+	}
+
+	/**
+	 * Handle the entities load event.
+	 * @param event The event to handle.
+	 */
+	@EventHandler
+	public void onEntitiesLoadEvent(final EntitiesLoadEvent event) {
+		event.getEntities().forEach(entity -> {
+			new ControllableEntity(plugin, entity).reactivateControl();
+		});
+	}
+}


### PR DESCRIPTION
… are unloaded and loaded again, mainly caused by relogging

<!-- BEGIN Global settings -->
<!-- TODO: Please describe your changes here. -->

---
<!-- Git and GitHub -->
- [x] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [x] Include a human-readable description of what the pull request is trying to accomplish
- [x] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
- [ ] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [ ] No (significant) changes to production code
---
<!-- Documentation -->
- [ ] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted:
<!-- END Global settings -->
---
<!-- Support matrix -->
- [ ] The change is unrelated to Minecraft
- [ ] Works in Java edition
- [ ] Works in Bedrock edition
